### PR TITLE
Updated Dockerfile to Fedora 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Tim Marcinowski <marshyski@gmail.com>
 USER root
 
 RUN yum -y update
-RUN yum install -y python-pip supervisor gcc nginx createrepo python-setuptools
+RUN yum install -y epel-release python-pip supervisor gcc nginx createrepo python-setuptools
 RUN rm -rf /usr/share/nginx
 ADD ./requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:20
+FROM fedora:21
 MAINTAINER Tim Marcinowski <marshyski@gmail.com>
 
 USER root


### PR DESCRIPTION
Docker build fails, due to failed dependencies. Updated Dockerfile to use Fedora 21